### PR TITLE
Not encoded url string should be invalid.

### DIFF
--- a/lib/utf8-cleaner/uri_string.rb
+++ b/lib/utf8-cleaner/uri_string.rb
@@ -71,6 +71,7 @@ module UTF8Cleaner
     end
 
     def valid_uri_encoded_utf8(string)
+      string.match(/^([!#$&-;=?-\[\]_a-z~]|%[0-9a-fA-F]{2})+$/) &&
       URI.decode(string).force_encoding('UTF-8').valid_encoding?
     end
 

--- a/lib/utf8-cleaner/uri_string.rb
+++ b/lib/utf8-cleaner/uri_string.rb
@@ -71,8 +71,11 @@ module UTF8Cleaner
     end
 
     def valid_uri_encoded_utf8(string)
-      string.match(/^([!#$&-;=?-\[\]_a-z~]|%[0-9a-fA-F]{2})+$/) &&
-      URI.decode(string).force_encoding('UTF-8').valid_encoding?
+      string.empty? ||
+      (
+        string.match(/^([!#$&-;=?-\[\]_a-z~]|%[0-9a-fA-F]{2})+$/) &&
+        URI.decode(string).force_encoding('UTF-8').valid_encoding?
+      )
     end
 
     # Grab the next num_bytes URI-encoded bytes from the raw character array.

--- a/spec/uri_string_spec.rb
+++ b/spec/uri_string_spec.rb
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 require 'spec_helper'
 
 module UTF8Cleaner
@@ -9,6 +11,7 @@ module UTF8Cleaner
     let(:multibyte_string) { URIString.new('%E2%9C%93') }
     let(:complex_invalid_string) { URIString.new('foo/%FFbar%2e%2fbaz%26%3B%E2%9C%93%E2%9Cbaz') }
                                                 # foo/   bar.  /  baz&  ;  √              baz
+    let(:not_encoded_invalid_string) { URIString.new('a??a�E�La??-a?��e3�300ao?-a/?a??a??ao��a?/1-8-1-15-1-17-a�C?a?/e��2a??e2�Ea�C�e�?a�C�-2') }
 
     describe '#new' do
       it { encoded_string.should be_a URIString }
@@ -38,6 +41,7 @@ module UTF8Cleaner
 
       it { invalid_string.should_not be_valid }
       it { complex_invalid_string.should_not be_valid }
+      it { not_encoded_invalid_string.should_not be_valid }
     end
 
   end

--- a/spec/uri_string_spec.rb
+++ b/spec/uri_string_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 module UTF8Cleaner
 
   describe URIString do
+    let(:empty_string)   { URIString.new('') }
     let(:invalid_string)   { URIString.new('%FF') }
     let(:ascii_string)     { URIString.new('foo') }
     let(:encoded_string)   { URIString.new('%26') }
@@ -35,6 +36,7 @@ module UTF8Cleaner
     end
 
     describe '#valid?' do
+      it { empty_string.should be_valid }
       it { ascii_string.should be_valid }
       it { encoded_string.should be_valid }
       it { multibyte_string.should be_valid }


### PR DESCRIPTION
Related to #6, some request does not encode url string at all, but just pass in Unicode characters as is. These should be invalid.