### PR TITLE
Remove invalid UTF-8 characters

### DIFF
--- a/lib/utf8-cleaner/middleware.rb
+++ b/lib/utf8-cleaner/middleware.rb
@@ -29,8 +29,21 @@ module UTF8Cleaner
     def sanitize_env_keys(env)
       SANITIZE_ENV_KEYS.each do |key|
         next unless value = env[key]
+
+        utf8_only_value = utf8_valid_string(value)
+        env[key] = value = utf8_only_value if utf8_only_value
+
         cleaned_value = cleaned_uri_string(value)
         env[key] = cleaned_value if cleaned_value
+      end
+    end
+
+    def utf8_valid_string(value)
+      unless value.frozen?
+        utf8_value = value.force_encoding("UTF-8")
+        unless utf8_value.valid_encoding?
+          utf8_value.encode("UTF-8", invalid: :replace, replace: "")
+        end
       end
     end
 

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -28,6 +28,17 @@ describe UTF8Cleaner::Middleware do
     it { new_env['REQUEST_URI'].should == '%C3%89%E2%9C%93' }
   end
 
+  describe "replaces invalid UTF-8 characters" do
+    before { env['QUERY_STRING'] = "foo=\x7fbar%FF\x80" }
+    it { new_env['QUERY_STRING'].should == "foo=\x7fbar" }
+  end
+
+  context "doesn't error when environment value is frozen" do
+    # Web servers can freeze environment values
+    before { env['QUERY_STRING'] = "".freeze }
+    it { new_env['QUERY_STRING'].should == "" }
+  end
+
   describe "when rack.input is wrapped" do
     # rack.input responds only to methods gets, each, rewind, read and close
     # Rack::Lint::InputWrapper is the class which servers wrappers are based on


### PR DESCRIPTION
There are cases where environment values coming in may contain non-CGI escaped
invalid UTF-8 characters. We have experienced this with requests coming in from
Windows Internet Explorer 11 with query strings that contain smart quotes
("\x93\x94") with our Rails server. This would invariably cause stack traces
further down the Rack stack because we had invalid strings.

The fix here removes invalid UTF-8 characters before passing it to
`cleaned_uri_string`.
