### PR TITLE
Added application/json as a POST body that is sanitized 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/lib/utf8-cleaner/middleware.rb
+++ b/lib/utf8-cleaner/middleware.rb
@@ -40,7 +40,7 @@ module UTF8Cleaner
 
     def sanitize_env_rack_input(env)
       case env['CONTENT_TYPE']
-      when 'application/x-www-form-urlencoded'
+      when 'application/x-www-form-urlencoded','application/json'
         cleaned_value = cleaned_string(env['rack.input'].read)
         env['rack.input'] = StringIO.new(cleaned_value) if cleaned_value
         env['rack.input'].rewind

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -10,14 +10,14 @@ module UTF8Cleaner
     describe "with a big nasty env" do
       let :env do
         {
-            'PATH_INFO' => 'foo/%FFbar%2e%2fbaz%26%3B',
-            'QUERY_STRING' => 'foo=bar%FF',
-            'HTTP_REFERER' => 'http://example.com/blog+Result:+%ED%E5+%ED%E0%F8%EB%EE%F1%FC+%F4%EE%F0%EC%FB+%E4%EB%FF+%EE%F2%EF%F0%E0%E2%EA%E8',
-            'HTTP_USER_AGENT' => "Android Versi\xF3n/4.0\x93",
-            'REQUEST_URI' => '%C3%89%E2%9C%93',
-            'rack.input' => StringIO.new("foo=%FFbar%F8"),
-            'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-            'HTTP_COOKIE' => nil
+          'PATH_INFO' => 'foo/%FFbar%2e%2fbaz%26%3B',
+          'QUERY_STRING' => 'foo=bar%FF',
+          'HTTP_REFERER' => 'http://example.com/blog+Result:+%ED%E5+%ED%E0%F8%EB%EE%F1%FC+%F4%EE%F0%EC%FB+%E4%EB%FF+%EE%F2%EF%F0%E0%E2%EA%E8',
+          'HTTP_USER_AGENT' => "Android Versi\xF3n/4.0\x93",
+          'REQUEST_URI' => '%C3%89%E2%9C%93',
+          'rack.input' => StringIO.new("foo=%FFbar%F8"),
+          'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+          'HTTP_COOKIE' => nil
         }
       end
 
@@ -71,8 +71,8 @@ module UTF8Cleaner
     describe "with a minimal env" do
       let(:env) do
         {
-            'PATH_INFO' => '/this/is/safe',
-            'QUERY_STRING' => 'foo=bar%FF'
+          'PATH_INFO' => '/this/is/safe',
+          'QUERY_STRING' => 'foo=bar%FF'
         }
       end
 
@@ -90,7 +90,7 @@ module UTF8Cleaner
     # E.g. make sure Rack/Rails won't choke on them
     after do
       cleaned = new_env
-      env.keys.reject { |key| key == 'rack.input' }.each do |key|
+      env.keys.reject{|key| key == 'rack.input'}.each do |key|
         URI.decode_www_form_component(cleaned[key]) if cleaned[key]
       end
     end


### PR DESCRIPTION
We have a webhook (Shopify) that is posting json using content-type application/json.
It fails in the rack middleware with Encoding::CompatibilityError (incompatible character encodings: UTF-8 and ASCII-8BIT).
After searching around I found your gem (thank you).
I added content-type application/json to the body sanitization case. Now I'm able to parse json properly.
Since json is by default UTF-8, I believe this solution is general purpose and could be pulled.
