### PR TITLE
Fix stripping of valid percent signs for JSON body input

### DIFF
--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -61,9 +61,17 @@ module UTF8Cleaner
         before do
           env['CONTENT_TYPE'] = 'application/json'
         end
-        it "removes removes invalid %-encoded UTF-8 sequences" do
+
+        it "tidys invalid UTF-8 sequences" do
+          env['rack.input'] = StringIO.new("{'foo'='\xFFbar\xF8'}")
           env['rack.input'].rewind
-          expect(new_env['rack.input'].read).to eq('foo=bar')
+          expect(new_env['rack.input'].read).to eq("{'foo'='\u00FFbar\u00F8'}")
+        end
+
+        it "does not tamper with validly URI encoded binary data that happens to be invalid UTF-8" do
+          env['rack.input'] = StringIO.new("{'foo'='%FFbar%F8'}")
+          env['rack.input'].rewind
+          expect(new_env['rack.input'].read).to eq("{'foo'='%FFbar%F8'}")
         end
       end
     end


### PR DESCRIPTION
This fixes the invalid stripping of percent characters from JSON body inputs introduced by PR #24. Invalid UTF-8 sequences in the JSON itself are still sanitized, but the data being represented by JSON is not necessarily UTF-8 sequences and so performing URI decoding of percent sequences is inappropriate.