### PR TITLE
Remove Rails 5 / Rack deprecation warning

### DIFF
--- a/lib/utf8-cleaner/railtie.rb
+++ b/lib/utf8-cleaner/railtie.rb
@@ -1,7 +1,7 @@
 module UTF8Cleaner
   class Railtie < Rails::Railtie
     initializer "utf8-cleaner.insert_middleware" do |app|
-      app.config.middleware.insert_before 0, "UTF8Cleaner::Middleware"
+      app.config.middleware.insert_before 0, UTF8Cleaner::Middleware
     end
   end
 end

--- a/utf8-cleaner.gemspec
+++ b/utf8-cleaner.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport'
 
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "listen", "3.0.8"
   gem.add_development_dependency "guard"
   gem.add_development_dependency "guard-rspec"
   gem.add_development_dependency "rspec"


### PR DESCRIPTION
Rails 5 / Rack 2 issues a deprecation warning when attempting to modify
the middleware stack with a string-enclosed middleware constant.