### PR TITLE
Pin `listen` to support full build matrix

### DIFF
--- a/utf8-cleaner.gemspec
+++ b/utf8-cleaner.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport'
 
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "listen", "3.0.8"
   gem.add_development_dependency "guard"
   gem.add_development_dependency "guard-rspec"
   gem.add_development_dependency "rspec"


### PR DESCRIPTION
`listen` gem dropped support for older Rubies after `3.0.8` so let's
pin the development dependency here and continue build support across
the travis matrix.

Ref: #28 