### PR TITLE
Implement host name sanitizing

### DIFF
--- a/lib/utf8-cleaner/middleware.rb
+++ b/lib/utf8-cleaner/middleware.rb
@@ -10,7 +10,8 @@ module UTF8Cleaner
      "QUERY_STRING",
      "REQUEST_PATH",
      "REQUEST_URI",
-     "HTTP_COOKIE"
+     "HTTP_COOKIE",
+     "SERVER_NAME"
     ]
 
     def initialize(app)

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -17,7 +17,8 @@ module UTF8Cleaner
           'REQUEST_URI' => '%C3%89%E2%9C%93',
           'rack.input' => StringIO.new("foo=%FFbar%F8"),
           'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-          'HTTP_COOKIE' => nil
+          'HTTP_COOKIE' => nil,
+          'SERVER_NAME' => "example.com\xD0"
         }
       end
 


### PR DESCRIPTION
Hello, I had many issues with Encoding::UndefinedConversionError with text `"\xD0" from ASCII-8BIT to UTF-8`. It comes from host name (because in my rails app I need to serve page depends on domain name).

It should fix that kind of problems.