### PR TITLE
Removing warnings for URI.decode because these method is now obsolete

### DIFF
--- a/lib/utf8-cleaner/uri_string.rb
+++ b/lib/utf8-cleaner/uri_string.rb
@@ -87,7 +87,7 @@ module UTF8Cleaner
     end
 
     def valid_uri_encoded_utf8(string)
-      URI.decode(string).force_encoding('UTF-8').valid_encoding? &&
+      URI::DEFAULT_PARSER.unescape(string).force_encoding('UTF-8').valid_encoding? &&
         string !~ INVALID_PERCENT_ENCODING_REGEX
     rescue ArgumentError => e
       if e.message =~ /invalid byte sequence/


### PR DESCRIPTION
Hi!
I am currently trying ruby 2.7.0 on my rails app and I get this deprecation warning:
```
~/.rvm/gems/ruby-2.7.0/gems/utf8-cleaner-0.2.5/lib/utf8-cleaner/uri_string.rb:90: warning: URI.unescape is obsolete
```

This is basically a fix for that deprecation warning.

Let me know if you think we can do better.

Thanks