### PR TITLE
Support Rack 3 and drop Rack 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,10 @@ jobs:
           - macos-latest
           - windows-latest
         exclude:
+          - ruby: ruby-2.4
+            os: macos-latest
+          - ruby: ruby-2.5
+            os: macos-latest
           - ruby: jruby-9.4
             os: windows-latest
           - ruby: truffleruby

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+---
+name: Test
+
+'on':
+  - push
+  - pull_request
+
+jobs:
+  # rubocop:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     CI: true
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Set up Ruby 3.4
+  #       uses: ruby/setup-ruby@v1
+  #       with:
+  #         ruby-version: 3.4
+  #         bundler-cache: true
+  #     - name: Run RuboCop
+  #       run: bundle exec rubocop --parallel
+
+  test:
+    name: "${{matrix.ruby}} ${{matrix.os || 'ubuntu-latest'}}"
+    env:
+      CI: true
+    runs-on: ${{matrix.os || 'ubuntu-latest'}}
+    continue-on-error: "${{matrix.experimental || false}}"
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - ruby-2.4
+          - ruby-2.5
+          - ruby-2.6
+          - ruby-2.7
+          - ruby-3.0
+          - ruby-3.1
+          - ruby-3.2
+          - ruby-3.3
+          - ruby-3.4
+          - jruby-9.4
+          - truffleruby
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        exclude:
+          - ruby: jruby-9.4
+            os: windows-latest
+          - ruby: truffleruby
+            os: windows-latest
+
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v3
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{matrix.ruby}}"
+      - name: bundle
+        run: bundle install --jobs 4 --retry 3
+      - name: test
+        timeout-minutes: 60
+        continue-on-error: "${{matrix.experimental || false}}"
+        run: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-before_install:
-  - gem install bundler
-language: ruby
-rvm:
-  - 2.3
-  - 2.4
-  - 2.5
-  - 2.6
-  - 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## v2.0.0
+
+* Support Rack 3 and add Rack >= 3.0 as a dependency
+* Dropped support for Ruby < 2.4 to match Rack
+* Replace Travis CI with GitHub Actions
+* Add frozen_string_literal to all files
+* Remove guard gem
+
 ## v1.0.0
 
 * Dropped support for Ruby < 2.3
@@ -36,4 +44,4 @@
 
 ## v0.1.0
 
-Broken.
+* Broken.

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in utf8-cleaner.gemspec
 gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,9 +1,0 @@
-# A sample Guardfile
-# More info at https://github.com/guard/guard#readme
-
-guard :rspec, cmd: 'bundle exec rspec -b' do
-  watch(%r{^spec/.+_spec\.rb$})
-  watch(%r{^lib/utf8-cleaner/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb') { "spec" }
-end
-

--- a/README.md
+++ b/README.md
@@ -2,27 +2,23 @@
 
 [![Build Status](https://secure.travis-ci.org/singlebrook/utf8-cleaner.png?branch=master)](http://travis-ci.org/singlebrook/utf8-cleaner)
 
-Removes invalid UTF-8 characters from the environment so that your app doesn't choke
-on them. This prevents errors like "invalid byte sequence in UTF-8".
+Rack middleware to remove invalid UTF-8 characters from the environment so that your
+app doesn't choke them. Prevents errors like "invalid byte sequence in UTF-8".
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your application's `Gemfile`:
 
-    gem 'utf8-cleaner'
+```ruby
+gem 'utf8-cleaner'
+```
 
-And then execute:
+If you're not running Rails, you'll have to add the middleware to your `config.ru`:
 
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install utf8-cleaner
-
-If you're not running Rails, you'll have to add the middleware to your config.ru:
-
-    require 'utf8-cleaner'
-    use UTF8Cleaner::Middleware
+```ruby
+require 'utf8-cleaner'
+use UTF8Cleaner::Middleware
+```
 
 ## Usage
 
@@ -38,10 +34,10 @@ There's nothing to "use". It just works!
 
 ## Credits
 
-Original middleware author: @phoet - https://gist.github.com/phoet/1336754
-
+* Original middleware author: @phoet - https://gist.github.com/phoet/1336754
 * Ruby 1.9.3 compatibility: @pithyless - https://gist.github.com/pithyless/3639014
 * Code review and cleanup: @nextmat
 * POST body sanitization: @salrepe
 * Bug fixes: @cosine
 * Rails 5 deprecation fix: @benlovell
+* Rack 3 support: @johnnyshields

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,8 @@
-require "bundler/gem_tasks"
+# frozen_string_literal: true
 
-task :default do
-  sh "rspec spec"
-end
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/lib/utf8-cleaner.rb
+++ b/lib/utf8-cleaner.rb
@@ -1,4 +1,6 @@
-require "utf8-cleaner/version"
-require "utf8-cleaner/middleware"
-require "utf8-cleaner/uri_string"
-require "utf8-cleaner/railtie" if defined? Rails
+# frozen_string_literal: true
+
+require 'utf8-cleaner/version'
+require 'utf8-cleaner/middleware'
+require 'utf8-cleaner/uri_string'
+require 'utf8-cleaner/railtie' if defined?(Rails)

--- a/lib/utf8-cleaner/middleware.rb
+++ b/lib/utf8-cleaner/middleware.rb
@@ -5,13 +5,13 @@ require 'active_support/multibyte/unicode'
 module UTF8Cleaner
   class Middleware
     SANITIZE_ENV_KEYS = %w[
-      http_referer
-      http_user_agent
-      path_info
-      query_string
-      request_path
-      request_uri
-      http_cookie
+      HTTP_REFERER
+      HTTP_USER_AGENT
+      PATH_INFO
+      QUERY_STRING
+      REQUEST_PATH
+      REQUEST_URI
+      HTTP_COOKIE
     ].freeze
 
     def initialize(app)
@@ -43,7 +43,7 @@ module UTF8Cleaner
     def sanitize_env_rack_input(env)
       return unless env['rack.input']
 
-      case env['content_type']
+      case env['CONTENT_TYPE']
       when %r{\Aapplication/x-www-form-urlencoded}i
         # This data gets the full cleaning treatment
         input_data = read_input(env['rack.input'])

--- a/lib/utf8-cleaner/railtie.rb
+++ b/lib/utf8-cleaner/railtie.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module UTF8Cleaner
   class Railtie < Rails::Railtie
-    initializer "utf8-cleaner.insert_middleware" do |app|
-      app.config.middleware.insert_before 0, UTF8Cleaner::Middleware
+    initializer('utf8-cleaner.insert_middleware') do |app|
+      app.config.middleware.insert_before(0, UTF8Cleaner::Middleware)
     end
   end
 end

--- a/lib/utf8-cleaner/uri_string.rb
+++ b/lib/utf8-cleaner/uri_string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module UTF8Cleaner
   # Cleans invalid %-encodings from URI-encoded strings.
   class URIString
@@ -32,7 +34,7 @@ module UTF8Cleaner
       char_array = []
       index = 0
 
-      while (index < data.length) do
+      while index < data.length do
         char = data[index]
 
         if char == '%'
@@ -129,6 +131,5 @@ module UTF8Cleaner
         4
       end
     end
-
   end
 end

--- a/lib/utf8-cleaner/version.rb
+++ b/lib/utf8-cleaner/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module UTF8Cleaner
-  VERSION = "1.0.0"
+  VERSION = '2.0.0'
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'rack/lint'
 
@@ -10,37 +12,37 @@ module UTF8Cleaner
     describe "with a big nasty env" do
       let :env do
         {
-          'PATH_INFO' => 'foo/%FFbar%2e%2fbaz%26%3B',
-          'QUERY_STRING' => 'foo=bar%FF',
-          'HTTP_REFERER' => 'http://example.com/blog+Result:+%ED%E5+%ED%E0%F8%EB%EE%F1%FC+%F4%EE%F0%EC%FB+%E4%EB%FF+%EE%F2%EF%F0%E0%E2%EA%E8',
-          'HTTP_USER_AGENT' => "Android Versi\xF3n/4.0\x93",
-          'REQUEST_URI' => '%C3%89%E2%9C%93',
+          'path_info' => 'foo/%FFbar%2e%2fbaz%26%3B',
+          'query_string' => 'foo=bar%FF',
+          'http_referer' => 'http://example.com/blog+Result:+%ED%E5+%ED%E0%F8%EB%EE%F1%FC+%F4%EE%F0%EC%FB+%E4%EB%FF+%EE%F2%EF%F0%E0%E2%EA%E8',
+          'http_user_agent' => "Android Versi\xF3n/4.0\x93",
+          'request_uri' => '%C3%89%E2%9C%93',
           'rack.input' => StringIO.new("foo=%FFbar%F8"),
-          'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-          'HTTP_COOKIE' => nil
+          'content_type' => 'application/x-www-form-urlencoded',
+          'http_cookie' => nil
         }
       end
 
       describe "removes invalid %-encoded UTF-8 sequences" do
-        it { expect(new_env['QUERY_STRING']).to eq('foo=bar') }
-        it { expect(new_env['HTTP_REFERER']).to eq('http://example.com/blog+Result:+++++') }
+        it { expect(new_env['query_string']).to eq('foo=bar') }
+        it { expect(new_env['http_referer']).to eq('http://example.com/blog+Result:+++++') }
         it { expect(new_env['rack.input'].read).to eq('foo=bar') }
       end
 
       describe 'replaces \x-encoded characters from the ISO-8859-1 and CP1252 code pages with their UTF-8 equivalents' do
-        it { expect(new_env['HTTP_USER_AGENT']).to eq("Android Versi\u00F3n/4.0\u201C") }
+        it { expect(new_env['http_user_agent']).to eq("Android Versi\u00F3n/4.0\u201C") }
       end
 
       describe "leaves all valid characters untouched" do
-        it { expect(new_env['PATH_INFO']).to eq('foo/bar%2e%2fbaz%26%3B') }
-        it { expect(new_env['REQUEST_URI']).to eq('%C3%89%E2%9C%93') }
+        it { expect(new_env['path_info']).to eq('foo/bar%2e%2fbaz%26%3B') }
+        it { expect(new_env['request_uri']).to eq('%C3%89%E2%9C%93') }
       end
 
       describe "when rack.input is wrapped" do
         # rack.input responds only to methods gets, each, rewind, read and close
         # Rack::Lint::InputWrapper is the class which servers wrappers are based on
         it "removes invalid UTF-8 sequences" do
-          wrapped_rack_input = Rack::Lint::InputWrapper.new(StringIO.new("foo=%FFbar%F8"))
+          wrapped_rack_input = Rack::Lint::Wrapper::InputWrapper.new(StringIO.new("foo=%FFbar%F8"))
           env.merge!('rack.input' => wrapped_rack_input)
           new_env = Middleware.new(nil).send(:sanitize_env, env)
           expect(new_env['rack.input'].read).to eq('foo=bar')
@@ -49,7 +51,7 @@ module UTF8Cleaner
 
       describe "when binary data is POSTed" do
         before do
-          env['CONTENT_TYPE'] = 'multipart/form-data'
+          env['content_type'] = 'multipart/form-data'
         end
         it "leaves the body alone" do
           env['rack.input'].rewind
@@ -59,7 +61,7 @@ module UTF8Cleaner
 
       describe "when json data is POSTed" do
         before do
-          env['CONTENT_TYPE'] = 'application/json'
+          env['content_type'] = 'application/json'
         end
 
         it "tidies invalid UTF-8 sequences" do
@@ -80,8 +82,8 @@ module UTF8Cleaner
     describe "with a minimal env" do
       let(:env) do
         {
-          'PATH_INFO' => '/this/is/safe',
-          'QUERY_STRING' => 'foo=bar%FF'
+          'path_info' => '/this/is/safe',
+          'query_string' => 'foo=bar%FF'
         }
       end
 
@@ -91,7 +93,7 @@ module UTF8Cleaner
       end
 
       it "leaves clean values alone" do
-        expect(new_env['PATH_INFO']).to eq('/this/is/safe')
+        expect(new_env['path_info']).to eq('/this/is/safe')
       end
     end
 
@@ -99,7 +101,7 @@ module UTF8Cleaner
     # E.g. make sure Rack/Rails won't choke on them
     after do
       cleaned = new_env
-      env.keys.reject{|key| key == 'rack.input'}.each do |key|
+      env.keys.reject { |key| key == 'rack.input' }.each do |key|
         URI.decode_www_form_component(cleaned[key]) if cleaned[key]
       end
     end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -12,30 +12,30 @@ module UTF8Cleaner
     describe "with a big nasty env" do
       let :env do
         {
-          'path_info' => 'foo/%FFbar%2e%2fbaz%26%3B',
-          'query_string' => 'foo=bar%FF',
-          'http_referer' => 'http://example.com/blog+Result:+%ED%E5+%ED%E0%F8%EB%EE%F1%FC+%F4%EE%F0%EC%FB+%E4%EB%FF+%EE%F2%EF%F0%E0%E2%EA%E8',
-          'http_user_agent' => "Android Versi\xF3n/4.0\x93",
-          'request_uri' => '%C3%89%E2%9C%93',
+          'PATH_INFO' => 'foo/%FFbar%2e%2fbaz%26%3B',
+          'QUERY_STRING' => 'foo=bar%FF',
+          'HTTP_REFERER' => 'http://example.com/blog+Result:+%ED%E5+%ED%E0%F8%EB%EE%F1%FC+%F4%EE%F0%EC%FB+%E4%EB%FF+%EE%F2%EF%F0%E0%E2%EA%E8',
+          'HTTP_USER_AGENT' => "Android Versi\xF3n/4.0\x93",
+          'REQUEST_URI' => '%C3%89%E2%9C%93',
           'rack.input' => StringIO.new("foo=%FFbar%F8"),
-          'content_type' => 'application/x-www-form-urlencoded',
-          'http_cookie' => nil
+          'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+          'HTTP_COOKIE' => nil
         }
       end
 
       describe "removes invalid %-encoded UTF-8 sequences" do
-        it { expect(new_env['query_string']).to eq('foo=bar') }
-        it { expect(new_env['http_referer']).to eq('http://example.com/blog+Result:+++++') }
+        it { expect(new_env['QUERY_STRING']).to eq('foo=bar') }
+        it { expect(new_env['HTTP_REFERER']).to eq('http://example.com/blog+Result:+++++') }
         it { expect(new_env['rack.input'].read).to eq('foo=bar') }
       end
 
       describe 'replaces \x-encoded characters from the ISO-8859-1 and CP1252 code pages with their UTF-8 equivalents' do
-        it { expect(new_env['http_user_agent']).to eq("Android Versi\u00F3n/4.0\u201C") }
+        it { expect(new_env['HTTP_USER_AGENT']).to eq("Android Versi\u00F3n/4.0\u201C") }
       end
 
       describe "leaves all valid characters untouched" do
-        it { expect(new_env['path_info']).to eq('foo/bar%2e%2fbaz%26%3B') }
-        it { expect(new_env['request_uri']).to eq('%C3%89%E2%9C%93') }
+        it { expect(new_env['PATH_INFO']).to eq('foo/bar%2e%2fbaz%26%3B') }
+        it { expect(new_env['REQUEST_URI']).to eq('%C3%89%E2%9C%93') }
       end
 
       describe "when rack.input is wrapped" do
@@ -51,7 +51,7 @@ module UTF8Cleaner
 
       describe "when binary data is POSTed" do
         before do
-          env['content_type'] = 'multipart/form-data'
+          env['CONTENT_TYPE'] = 'multipart/form-data'
         end
         it "leaves the body alone" do
           env['rack.input'].rewind
@@ -61,7 +61,7 @@ module UTF8Cleaner
 
       describe "when json data is POSTed" do
         before do
-          env['content_type'] = 'application/json'
+          env['CONTENT_TYPE'] = 'application/json'
         end
 
         it "tidies invalid UTF-8 sequences" do
@@ -82,8 +82,8 @@ module UTF8Cleaner
     describe "with a minimal env" do
       let(:env) do
         {
-          'path_info' => '/this/is/safe',
-          'query_string' => 'foo=bar%FF'
+          'PATH_INFO' => '/this/is/safe',
+          'QUERY_STRING' => 'foo=bar%FF'
         }
       end
 
@@ -93,7 +93,7 @@ module UTF8Cleaner
       end
 
       it "leaves clean values alone" do
-        expect(new_env['path_info']).to eq('/this/is/safe')
+        expect(new_env['PATH_INFO']).to eq('/this/is/safe')
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'utf8-cleaner'
 require 'uri'

--- a/spec/uri_string_spec.rb
+++ b/spec/uri_string_spec.rb
@@ -1,4 +1,5 @@
-# encoding: UTF-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 module UTF8Cleaner
@@ -8,8 +9,10 @@ module UTF8Cleaner
     let(:ascii_string)     { URIString.new('foo') }
     let(:encoded_string)   { URIString.new('%26') }
     let(:multibyte_string) { URIString.new('%E2%9C%93') }
-    let(:complex_invalid_string) { URIString.new('foo/%FFbar%2e%2fbaz%26%3B%E2%9C%93%E2%9Cbaz') }
-                                                # foo/   bar.  /  baz&  ;  √              baz
+    let(:complex_invalid_string) do
+      # ------------ foo/   bar.  /  baz&  ;  √              baz
+      URIString.new('foo/%FFbar%2e%2fbaz%26%3B%E2%9C%93%E2%9Cbaz')
+    end
     let(:no_byte_at_all)      { URIString.new('%') }
     let(:not_even_hex_chars1) { URIString.new('%x') }
     let(:not_even_hex_chars2) { URIString.new('%0zhey') }
@@ -35,7 +38,6 @@ module UTF8Cleaner
       it { expect(ascii_string).to be_valid }
       it { expect(encoded_string).to be_valid }
       it { expect(multibyte_string).to be_valid }
-
       it { expect(invalid_string).to_not be_valid }
       it { expect(complex_invalid_string).to_not be_valid }
       it { expect(no_byte_at_all).to_not be_valid }
@@ -43,7 +45,5 @@ module UTF8Cleaner
       it { expect(not_even_hex_chars2).to_not be_valid }
       it { expect(mixed_encodings).to_not be_valid }
     end
-
   end
-
 end

--- a/utf8-cleaner.gemspec
+++ b/utf8-cleaner.gemspec
@@ -1,31 +1,27 @@
-# -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'utf8-cleaner/version'
+# frozen_string_literal: true
+
+require_relative 'lib/utf8-cleaner/version'
 
 Gem::Specification.new do |gem|
-  gem.name          = "utf8-cleaner"
+  gem.name          = 'utf8-cleaner'
   gem.version       = UTF8Cleaner::VERSION
-  gem.authors       = ["Leon Miller-Out"]
-  gem.email         = ["leon@singlebrook.com"]
-  gem.description   = %q{Removes invalid UTF8 characters from the URL and other env vars}
-  gem.summary       = %q{Prevent annoying error reports of "invalid byte sequence in UTF-8"}
-  gem.homepage      = "https://github.com/singlebrook/utf8-cleaner"
-  gem.license       = "MIT"
+  gem.authors       = ['Leon Miller-Out']
+  gem.email         = ['leon@singlebrook.com']
+  gem.description   = %q{Rack middleware to remove invalid UTF8 characters from web requests.}
+  gem.summary       = %q{Prevent annoying 'invalid byte sequence in UTF-8' errors}
+  gem.homepage      = 'https://github.com/singlebrook/utf8-cleaner'
+  gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ['lib']
 
-  gem.required_ruby_version = ">= 2.3.0"
+  gem.required_ruby_version = '>= 2.4'
 
   gem.add_dependency 'activesupport'
+  gem.add_dependency 'rack', '>= 3.0'
 
-  gem.add_development_dependency "rake"
-  gem.add_development_dependency "listen", "3.0.8"
-  gem.add_development_dependency "guard"
-  gem.add_development_dependency "guard-rspec"
-  gem.add_development_dependency "rspec"
-  gem.add_development_dependency "rack"
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rspec'
 end


### PR DESCRIPTION
- Support Rack 3 and add Rack >= 3.0 as a dependency
- Dropped support for Ruby < 2.4 to match Rack
- Replace Travis CI with GitHub Actions
- Add frozen_string_literal to all files
- Remove guard gem

Please enable Github Actions CI so tests can run. You can see passing tests here: https://github.com/johnnyshields/utf8-cleaner/actions/runs/16769523391